### PR TITLE
Trigger go-license-detector database loading on start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ Debug = true
 
 Athens proxy should be configured properly by setting `ATHENS_PROXY_VALIDATOR` environment variable or `ValidatorHook` parameter in config to `<base-url of app>/athens/admission`
 
-## Caveats
-* Regexp-based [go-license-detector](https://godoc.org/gopkg.in/src-d/go-license-detector.v3) is slow, very slow. Simple license detection (only single file with license text) takes approx 2s on MacBook Pro (15-inch, 2017)
-
 ## Running tests
 This project contains integration tests that uses [testcontainers-go](https://github.com/testcontainers/testcontainers-go).
 They can be skipped using `-short` flag. Correct running requires working Docker.

--- a/athens_integration/suite_test.go
+++ b/athens_integration/suite_test.go
@@ -155,6 +155,7 @@ func (s *AthensIntegrationTestSuite) TearDownSuite() {
 }
 
 func TestAthensIntegration_suite(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 		return

--- a/cmd/licensevalidator/app/app.go
+++ b/cmd/licensevalidator/app/app.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
+	"github.com/xakep666/licensevalidator/internal/preload"
 	"github.com/xakep666/licensevalidator/pkg/athens"
 	"github.com/xakep666/licensevalidator/pkg/cache"
 	"github.com/xakep666/licensevalidator/pkg/github"
@@ -57,6 +58,9 @@ func NewApp(cfg Config) (*App, error) {
 	}
 
 	logger.Info("Running with config", zap.Reflect("config", cfg))
+
+	logger.Info("Loading license database")
+	preload.LicenseDB()
 
 	tracer, tracerFlush, err := setupTracer(&cfg, logger)
 	if err != nil {

--- a/cmd/licensevalidator/main_test.go
+++ b/cmd/licensevalidator/main_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAppRunsWithSample(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skipf("Skip integration test in short mode")
 		return

--- a/cmd/licensevalidator/main_test.go
+++ b/cmd/licensevalidator/main_test.go
@@ -94,7 +94,7 @@ func TestAppRunsWithSample(t *testing.T) {
 
 			t.Logf("Probe response code is %d", resp.StatusCode)
 			return resp.StatusCode < http.StatusInternalServerError
-		}, 20*time.Second, 2*time.Second, "server didn't become ready")
+		}, 5*time.Minute, 10*time.Second, "server didn't become ready")
 
 		// send sigterm to stop app
 		interruptChan <- syscall.SIGTERM

--- a/internal/preload/licensedb.go
+++ b/internal/preload/licensedb.go
@@ -1,0 +1,37 @@
+package preload
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-license-detector.v3/licensedb"
+	"gopkg.in/src-d/go-license-detector.v3/licensedb/filer"
+)
+
+// LicenseDB loads license db. This needed to not slow down first query processing.
+// go-license-detector holds license database in asset and loads and parses it.
+// This process guarded by sync.Once inside library.
+func LicenseDB() {
+	_, _ = licensedb.Detect(preloadFiler{})
+}
+
+type preloadFiler struct{}
+
+func (preloadFiler) ReadFile(path string) (content []byte, err error) {
+	if path != "LICENSE" {
+		return nil, fmt.Errorf("unknown file: %s", path)
+	}
+
+	return []byte("SOME TEXT"), nil
+}
+
+func (preloadFiler) ReadDir(path string) ([]filer.File, error) {
+	if path != "" {
+		return nil, nil
+	}
+
+	return []filer.File{{Name: "LICENSE"}}, nil
+}
+
+func (preloadFiler) Close() {}
+
+func (preloadFiler) PathsAreAlwaysSlash() bool { return true }

--- a/pkg/athens/admission_test.go
+++ b/pkg/athens/admission_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAdmissionHandler(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Name               string
 		Request            *http.Request
@@ -128,6 +129,7 @@ func TestAdmissionHandler(t *testing.T) {
 }
 
 func TestAdmissionHandler_prevents_misconfiguration(t *testing.T) {
+	t.Parallel()
 	var validatorMock athens.ValidatorMock
 	defer validatorMock.AssertExpectations(t)
 

--- a/pkg/athens/validator_test.go
+++ b/pkg/athens/validator_test.go
@@ -95,5 +95,6 @@ func (s *InternalValidatorTestSuite) TearDownTest() {
 }
 
 func TestInternalValidator_Suite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(InternalValidatorTestSuite))
 }

--- a/pkg/cache/memlru_test.go
+++ b/pkg/cache/memlru_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestMemLRU_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	var licenseResolverMock validation.LicenseResolverMock
 	defer licenseResolverMock.AssertExpectations(t)
 
@@ -49,6 +50,7 @@ func TestMemLRU_ResolveLicense(t *testing.T) {
 }
 
 func TestMemLRU_ResolveLicense_error_not_cached(t *testing.T) {
+	t.Parallel()
 	var licenseResolverMock validation.LicenseResolverMock
 	defer licenseResolverMock.AssertExpectations(t)
 
@@ -82,6 +84,7 @@ func TestMemLRU_ResolveLicense_error_not_cached(t *testing.T) {
 }
 
 func TestNewMemLRU_ResolveLicense_eviction(t *testing.T) {
+	t.Parallel()
 	var licenseResolverMock validation.LicenseResolverMock
 	defer licenseResolverMock.AssertExpectations(t)
 

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestMemoryCache_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	var licenseResolverMock validation.LicenseResolverMock
 	defer licenseResolverMock.AssertExpectations(t)
 
@@ -47,6 +48,7 @@ func TestMemoryCache_ResolveLicense(t *testing.T) {
 }
 
 func TestMemoryCache_ResolveLicense_error_not_cached(t *testing.T) {
+	t.Parallel()
 	var licenseResolverMock validation.LicenseResolverMock
 	defer licenseResolverMock.AssertExpectations(t)
 

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -94,6 +94,7 @@ func (s *RedisCacheTestSuite) TearDownSuite() {
 }
 
 func TestRedisCache_Suite(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skipf("Skipping integration test in short mode")
 		return

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -74,6 +74,7 @@ const (
 )
 
 func TestClient_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	mockedServerMux := http.NewServeMux()
 	mockedServerMux.HandleFunc("/repos/test/mit/license", func(w http.ResponseWriter, r *http.Request) {
 		serveJSON(w, http.StatusOK, json.RawMessage(mitJSON))

--- a/pkg/golang/translator_test.go
+++ b/pkg/golang/translator_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTranslator_Translate(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Input  string
 		Output string

--- a/pkg/gopkg/translator_test.go
+++ b/pkg/gopkg/translator_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTranslator_Translate(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Input  string
 		Output string

--- a/pkg/goproxy/filer_test.go
+++ b/pkg/goproxy/filer_test.go
@@ -24,6 +24,7 @@ func openTestZip(t *testing.T) *zip.Reader {
 }
 
 func TestZipFiler_ReadFile(t *testing.T) {
+	t.Parallel()
 	filer := &goproxy.ZipFiler{
 		Reader: openTestZip(t),
 		Module: validation.Module{
@@ -69,6 +70,7 @@ go 1.13
 }
 
 func TestZipFiler_ReadDir(t *testing.T) {
+	t.Parallel()
 	filer := &goproxy.ZipFiler{
 		Reader: openTestZip(t),
 		Module: validation.Module{

--- a/pkg/goproxy/resolver_test.go
+++ b/pkg/goproxy/resolver_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestClient_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	mockedServerMux := http.NewServeMux()
 	mockedServerMux.HandleFunc("/github.com/stretchr/testify/@v/v1.5.1.zip", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, path.Join("testdata", "testify-1.5.1.zip"))

--- a/pkg/observ/trace_test.go
+++ b/pkg/observ/trace_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestTraceTransport_RoundTrip(t *testing.T) {
+	t.Parallel()
 	var spanBuffer bytes.Buffer
 
 	exp, err := stdout.NewExporter(stdout.Options{

--- a/pkg/override/translator_test.go
+++ b/pkg/override/translator_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestTranslator_Translate(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Overrides []override.TranslateOverride
 		Input     string

--- a/pkg/spdx/spdx_test.go
+++ b/pkg/spdx/spdx_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestLicenseByID(t *testing.T) {
+	t.Parallel()
 	t.Run("find MIT", func(t *testing.T) {
 		licInfo, ok := spdx.LicenseByID("MIT")
 		if assert.True(t, ok, "MIT present in SPDX but not found") {

--- a/pkg/validation/chain_test.go
+++ b/pkg/validation/chain_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestChainedTranslator_Translate(t *testing.T) {
+	t.Parallel()
 	var (
 		tr1, tr2, tr3 validation.TranslatorMock
 	)
@@ -60,6 +61,7 @@ func TestChainedTranslator_Translate(t *testing.T) {
 }
 
 func TestChainedTranslator_Translate_error(t *testing.T) {
+	t.Parallel()
 	var (
 		tr1, tr2 validation.TranslatorMock
 	)
@@ -82,6 +84,7 @@ func TestChainedTranslator_Translate_error(t *testing.T) {
 }
 
 func TestChainedLicenseResolver_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	var (
 		r1, r2 validation.LicenseResolverMock
 	)
@@ -109,6 +112,7 @@ func TestChainedLicenseResolver_ResolveLicense(t *testing.T) {
 }
 
 func TestChainedLicenseResolver_ResolveLicense_error(t *testing.T) {
+	t.Parallel()
 	var (
 		r1, r2 validation.LicenseResolverMock
 	)

--- a/pkg/validation/notifying_test.go
+++ b/pkg/validation/notifying_test.go
@@ -111,5 +111,6 @@ func (s *NotifyingValidatorTestSuite) TearDownTest() {
 }
 
 func TestNotifyingValidator_Suite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(NotifyingValidatorTestSuite))
 }

--- a/pkg/validation/ruleset_test.go
+++ b/pkg/validation/ruleset_test.go
@@ -20,6 +20,7 @@ func MustParseConstraint(constraint string) *semver.Constraints {
 }
 
 func TestRuleSet_Validate(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Name          string
 		Module        validation.LicensedModule
@@ -135,6 +136,7 @@ func TestRuleSet_Validate(t *testing.T) {
 }
 
 func TestModuleMatcher_Match(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Name          string
 		Module        validation.Module

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -120,5 +120,6 @@ func (s *ValidatorTestSuite) TearDownSuite() {
 }
 
 func TestValidator_Suite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, new(ValidatorTestSuite))
 }

--- a/pkg/validation/webhook_test.go
+++ b/pkg/validation/webhook_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestLicenseResolverMock_ResolveLicense(t *testing.T) {
+	t.Parallel()
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 


### PR DESCRIPTION
This is slow process guarded by sync.Once.
So for better response time stability it loaded when application starts.

Closes #11 